### PR TITLE
Adds statifier-ex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,45 @@ Thumbs.db
 
 # Editor-made files
 *.swp
+
+# Elixir
+
+# The directory Mix will write compiled artifacts to.
+*-ex/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+*-ex/cover/
+
+# The directory Mix downloads your dependencies sources to.
+*-ex/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+*-ex/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+*-ex/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# If NPM crashes, it generates a log, let's ignore it too.
+npm-debug.log
+
+# The directory NPM downloads your dependencies sources to.
+*-ex/assets/node_modules/
+
+# Since we are building assets from assets/,
+# we ignore priv/static. You may want to comment
+# this depending on your deployment strategy.
+*-ex/priv/static/
+
+# Files matching config/*.secret.exs pattern contain sensitive
+# data and you should not commit them into version control.
+#
+# Alternatively, you may comment the line below and commit the
+# secrets files as long as you replace their contents by environment
+# variables.
+*-ex/config/*.secret.exs

--- a/statifier-ex/.formatter.exs
+++ b/statifier-ex/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/statifier-ex/README.md
+++ b/statifier-ex/README.md
@@ -1,0 +1,20 @@
+# Statifier
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `statifier` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:statifier, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/statifier](https://hexdocs.pm/statifier).

--- a/statifier-ex/config/config.exs
+++ b/statifier-ex/config/config.exs
@@ -1,0 +1,30 @@
+# This file is responsible for configuring your application
+# and its dependencies with the aid of the Mix.Config module.
+use Mix.Config
+
+# This configuration is loaded before any dependency and is restricted
+# to this project. If another project depends on this project, this
+# file won't be loaded nor affect the parent project. For this reason,
+# if you want to provide default values for your application for
+# third-party users, it should be done in your "mix.exs" file.
+
+# You can configure your application as:
+#
+#     config :statifier, key: :value
+#
+# and access this configuration in your application as:
+#
+#     Application.get_env(:statifier, :key)
+#
+# You can also configure a third-party app:
+#
+#     config :logger, level: :info
+#
+
+# It is also possible to import configuration files, relative to this
+# directory. For example, you can emulate configuration per environment
+# by uncommenting the line below and defining dev.exs, test.exs and such.
+# Configuration from the imported file will override the ones defined
+# here (which is why it is important to import them last).
+#
+#     import_config "#{Mix.env()}.exs"

--- a/statifier-ex/lib/statifier.ex
+++ b/statifier-ex/lib/statifier.ex
@@ -1,0 +1,11 @@
+defmodule Statifier do
+  @moduledoc """
+  Documentation for Statifier.
+  """
+
+  def machine_from_file path do
+    {:ok, xmldoc} = File.read Path.expand path
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+    Statifier.Machine.new statechart
+  end
+end

--- a/statifier-ex/lib/statifier/configuration.ex
+++ b/statifier-ex/lib/statifier/configuration.ex
@@ -1,0 +1,20 @@
+defmodule Statifier.Configuration do
+  defstruct [:active]
+
+  def initial(state) do
+    initial_config = state |> Statifier.State.get_initial
+    %__MODULE__{active: initial_config}
+  end
+
+  #def transition!(%__MODULE__{} = configuration, transition) do
+  #  target_state = machine.states |> Enum.find(fn state -> state.id == transition.target end)
+  #end
+
+  def new(new_config) do
+    %__MODULE__{active: new_config}
+  end
+
+  def literal(%__MODULE__{} = configuration) do
+    Enum.map(configuration.active, fn state -> state.id end)
+  end
+end

--- a/statifier-ex/lib/statifier/machine.ex
+++ b/statifier-ex/lib/statifier/machine.ex
@@ -1,0 +1,71 @@
+defmodule Statifier.Machine do
+  defstruct [
+    # Root state
+    :root,
+
+    :states,
+
+    # Currently active states
+    :configuration
+  ]
+
+  def new statechart do
+    root = Statifier.State.new(statechart.root)
+
+    %__MODULE__{
+      root: root,
+      states: Statifier.State.gather_states(root),
+      configuration: Statifier.Configuration.initial(root)
+    }
+  end
+
+  # Literal representation of the configuration
+  def configuration_literal(%__MODULE__{} = machine) do
+    Statifier.Configuration.literal machine.configuration
+  end
+
+  # Transitions defined on current configuration
+  def transitions(%__MODULE__{} = machine) do
+    machine.configuration.active
+    |> Enum.reduce([], fn state, acc ->
+      acc ++ Statifier.State.gather_transitions(state)
+    end)
+    |> List.flatten
+  end
+
+  def send(%__MODULE__{} = machine, event) do
+    matching_transitions = machine
+      |> transitions
+      |> Enum.filter(fn transition -> transition.event == event end)
+
+    if length(matching_transitions) == 0 do
+      machine
+    else
+      # TODO: handle multiple transitions
+      [ first | _tail ] = matching_transitions
+      machine
+      |> transition!([first])
+      #machine
+      #|> transition!(matching_transitions)
+    end
+  end
+
+  def transition!(%__MODULE__{} = machine, transitions) do
+    changes = transitions
+      |> Enum.map(fn transition ->
+          %{
+            source: machine.states |> Enum.find(fn state -> state.id == transition.source end),
+            target: machine.states |> Enum.find(fn state -> state.id == transition.target end)
+          }
+        end)
+
+    new_states = changes
+      |> Enum.reduce(machine.configuration.active, fn x, acc ->
+        new_list = acc |> List.delete(x.source)
+
+        new_list ++ (x.target |> Statifier.State.get_initial)
+      end)
+
+    %__MODULE__{machine | configuration: Statifier.Configuration.new(new_states)}
+  end
+end

--- a/statifier-ex/lib/statifier/scxml.ex
+++ b/statifier-ex/lib/statifier/scxml.ex
@@ -1,0 +1,35 @@
+defmodule Statifier.Scxml do
+  import SweetXml
+
+  # Return a map of the statechart
+  def parse_statechart xml_string do
+    xml_string
+    |> SweetXml.parse
+    |> SweetXml.xpath(~x"/scxml")
+    |> xml_to_map
+    |> Statifier.Statechart.new
+  end
+
+  def xml_to_map xml do
+    initial = xml |> xpath(~x"./@initial"s)
+    id = xml |> xpath(~x"./@id"s)
+    type = xml |> xpath(~x"name()"s)
+
+    transitions = xml
+                  |> xpath(~x"./transition"l,
+                    target: ~x"./@target"s,
+                    event: ~x"./@event"s
+                  )
+    states = xml
+      |> xpath(~x"./state | ./parallel"l)
+      |> Enum.map(fn (state_element) -> xml_to_map(state_element) end)
+
+    %{
+      id: id,
+      type: type,
+      initial: initial,
+      transitions: transitions,
+      states: states
+    }
+  end
+end

--- a/statifier-ex/lib/statifier/state.ex
+++ b/statifier-ex/lib/statifier/state.ex
@@ -1,0 +1,58 @@
+defmodule Statifier.State do
+  def get_initial(%Statifier.States.AtomicState{} = state) do
+    [state]
+  end
+
+  def get_initial(%Statifier.States.CompoundState{} = state) do
+    (Enum.find(state.states, fn child -> state.initial_attribute == child.id end) ||
+      List.first state.states)
+      |> get_initial
+  end
+
+  def get_initial(%Statifier.States.ParallelState{} = state) do
+    state.states
+      |> Enum.map(fn child -> child |> get_initial end)
+      |> List.flatten
+  end
+
+
+
+  def gather_states(%Statifier.States.AtomicState{} = state) do
+    [state]
+  end
+
+  def gather_states(state) do
+    state.states
+      |> Enum.map(fn child -> child |> gather_states end)
+      |> List.flatten([state])
+  end
+
+
+
+  def gather_transitions(%Statifier.States.AtomicState{} = state) do
+    state.transitions
+  end
+
+  def gather_transitions(state) do
+    state.states
+      |> Enum.map(fn child -> child |> gather_transitions end)
+      |> List.flatten
+  end
+
+
+
+  def new(definition) do
+    new definition, []
+  end
+
+  def new(definition, transitions) do
+    cond do
+      length(definition.states) == 0 ->
+        Statifier.States.AtomicState.new definition, transitions
+      definition.type == "parallel" ->
+        Statifier.States.ParallelState.new definition, transitions
+      true ->
+        Statifier.States.CompoundState.new definition, transitions
+    end
+  end
+end

--- a/statifier-ex/lib/statifier/statechart.ex
+++ b/statifier-ex/lib/statifier/statechart.ex
@@ -1,0 +1,7 @@
+defmodule Statifier.Statechart do
+  defstruct [ :root ]
+
+  def new root do
+    %__MODULE__{root: root}
+  end
+end

--- a/statifier-ex/lib/statifier/states/atomic_state.ex
+++ b/statifier-ex/lib/statifier/states/atomic_state.ex
@@ -1,0 +1,20 @@
+defmodule Statifier.States.AtomicState do
+  defstruct [
+    :id,
+    :path,
+    :transitions
+  ]
+
+  def new(definition, parent_transitions) do
+    transitions = definition.transitions
+                  |> Enum.map(fn transition ->
+                    Statifier.Transition.new(definition.id, transition.target, transition.event)
+                  end)
+                  |> List.flatten(parent_transitions)
+
+    %__MODULE__{
+      id: definition.id,
+      transitions: transitions
+    }
+  end
+end

--- a/statifier-ex/lib/statifier/states/compound_state.ex
+++ b/statifier-ex/lib/statifier/states/compound_state.ex
@@ -1,0 +1,26 @@
+defmodule Statifier.States.CompoundState do
+  defstruct [
+    :id,
+    :initial_attribute,
+    :states,
+    :transitions
+  ]
+
+  def new(definition, parent_transitions) do
+    transitions = definition.transitions
+                  |> Enum.map(fn transition ->
+                    Statifier.Transition.new(definition.id, transition.target, transition.event)
+                  end)
+                  |> List.flatten(parent_transitions)
+
+    states = definition.states
+      |> Enum.map(fn child -> Statifier.State.new(child, transitions) end)
+
+    %__MODULE__{
+      id: definition.id,
+      initial_attribute: definition.initial,
+      states: states,
+      transitions: transitions
+    }
+  end
+end

--- a/statifier-ex/lib/statifier/states/parallel_state.ex
+++ b/statifier-ex/lib/statifier/states/parallel_state.ex
@@ -1,0 +1,26 @@
+defmodule Statifier.States.ParallelState do
+  defstruct [
+    :id,
+    :initial_attribute,
+    :states,
+    :transitions
+  ]
+
+  def new(definition, parent_transitions) do
+    transitions = definition.transitions
+                  |> Enum.map(fn transition ->
+                    Statifier.Transition.new(definition.id, transition.target, transition.event)
+                  end)
+                  |> List.flatten(parent_transitions)
+
+    states = definition.states
+      |> Enum.map(fn child -> Statifier.State.new(child, transitions) end)
+
+    %__MODULE__{
+      id: definition.id,
+      initial_attribute: definition.initial,
+      states: states,
+      transitions: transitions
+    }
+  end
+end

--- a/statifier-ex/lib/statifier/transition.ex
+++ b/statifier-ex/lib/statifier/transition.ex
@@ -1,0 +1,15 @@
+defmodule Statifier.Transition do
+  defstruct [
+    :source,
+    :target,
+    :event
+  ]
+
+  def new(source, target, event) do
+    %__MODULE__{
+      source: source,
+      target: target,
+      event: event
+    }
+  end
+end

--- a/statifier-ex/mix.exs
+++ b/statifier-ex/mix.exs
@@ -1,0 +1,46 @@
+defmodule Statifier.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :statifier,
+      version: "0.1.0",
+      elixir: "~> 1.8",
+      start_permanent: Mix.env() == :prod,
+      docs: [extras: ["README.md"]],
+      dialyzer: [plt_add_deps: :transitive],
+      description: description(),
+      package: package(),
+      deps: deps()
+    ]
+  end
+
+
+  def description, do: "Statecharts for Elixir"
+
+  def package do
+    [
+      name: :statifier,
+      maintainers: ["JohnnyT"],
+      licenses: ["MIT"],
+      docs: [extras: ["README.md"]],
+      links: %{"GitHub" => "https://github.com/riddler/statifier-ex"}
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:poison, ">= 0.0.0"},
+      {:sweet_xml, ">= 0.0.0"}
+    ]
+  end
+end

--- a/statifier-ex/mix.lock
+++ b/statifier-ex/mix.lock
@@ -1,0 +1,9 @@
+%{
+  "earmark": {:hex, :earmark, "1.3.6", "ce1d0675e10a5bb46b007549362bd3f5f08908843957687d8484fe7f37466b19", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "poison": {:hex, :poison, "4.0.1", "bcb755a16fac91cad79bfe9fc3585bb07b9331e50cfe3420a24bcc2d735709ae", [:mix], [], "hexpm"},
+  "sweet_xml": {:hex, :sweet_xml, "0.6.6", "fc3e91ec5dd7c787b6195757fbcf0abc670cee1e4172687b45183032221b66b8", [:mix], [], "hexpm"},
+}

--- a/statifier-ex/test/fixtures/scxml/basic/basic0.json
+++ b/statifier-ex/test/fixtures/scxml/basic/basic0.json
@@ -1,0 +1,6 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : []
+}
+
+

--- a/statifier-ex/test/fixtures/scxml/basic/basic0.scxml
+++ b/statifier-ex/test/fixtures/scxml/basic/basic0.scxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="a">
+
+    <state id="a"/>
+
+</scxml>
+
+
+
+

--- a/statifier-ex/test/fixtures/scxml/basic/basic1.json
+++ b/statifier-ex/test/fixtures/scxml/basic/basic1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/basic/basic1.scxml
+++ b/statifier-ex/test/fixtures/scxml/basic/basic1.scxml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+</scxml>

--- a/statifier-ex/test/fixtures/scxml/basic/basic2.json
+++ b/statifier-ex/test/fixtures/scxml/basic/basic2.json
@@ -1,0 +1,16 @@
+{
+    "initialConfiguration" : ["a"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        },
+        {
+            "event" : { "name" : "t2" },
+            "nextConfiguration" : ["c"]
+        }
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/basic/basic2.scxml
+++ b/statifier-ex/test/fixtures/scxml/basic/basic2.scxml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <transition target="b" event="t"/>
+    </state>
+
+    <state id="b">
+        <transition target="c" event="t2"/>
+    </state>
+
+    <state id="c"/>
+
+</scxml>
+
+
+
+

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier0.json
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier0.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2"]
+        }
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier0.scxml
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier0.scxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="a2" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+    </state>
+
+
+</scxml>

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier1.json
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier1.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "e-hier1" },
+            "nextConfiguration" : ["a2"]
+        }
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier1.scxml
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier1.scxml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="a2" event="e-hier1"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="b" event="e-hier1"/>
+    </state>
+
+    <state id="b"/>
+
+
+</scxml>
+

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier2.json
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier2.json
@@ -1,0 +1,12 @@
+{
+    "initialConfiguration" : ["a1"],
+    "events" : [
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["b"]
+        }
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/hierarchy/hier2.scxml
+++ b/statifier-ex/test/fixtures/scxml/hierarchy/hier2.scxml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <state id="a">
+        <state id="a1">
+            <transition target="b" event="t"/>
+        </state>
+
+        <state id="a2">
+        </state>
+
+        <transition target="a2" event="t"/>
+    </state>
+
+    <state id="b"/>
+
+
+</scxml>
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test0.json
+++ b/statifier-ex/test/fixtures/scxml/parallel/test0.json
@@ -1,0 +1,7 @@
+{
+    "initialConfiguration" : ["a","b"],
+    "events" : [ ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test0.scxml
+++ b/statifier-ex/test/fixtures/scxml/parallel/test0.scxml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a"/>
+
+        <state id="b"/>
+    </parallel>
+
+
+</scxml>
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test1.json
+++ b/statifier-ex/test/fixtures/scxml/parallel/test1.json
@@ -1,0 +1,13 @@
+{
+    "initialConfiguration" : ["a1","b1"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["a2","b2"]
+        }
+
+    ]
+}
+
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test1.scxml
+++ b/statifier-ex/test/fixtures/scxml/parallel/test1.scxml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<scxml 
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p">
+        <state id="a">
+            <initial>
+                <transition target="a1"/>
+            </initial>
+
+            <state id="a1">
+                <transition event="t" target="a2"/>
+            </state>
+
+            <state id="a2"/>
+        </state>
+
+        <state id="b">
+            <initial>
+                <transition target="b1"/>
+            </initial>
+
+            <state id="b1">
+                <transition event="t" target="b2"/>
+            </state>
+
+            <state id="b2"/>
+        </state>
+    </parallel>
+
+
+</scxml>
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test2.json
+++ b/statifier-ex/test/fixtures/scxml/parallel/test2.json
@@ -1,0 +1,14 @@
+{
+    "initialConfiguration" : ["s3","s4","s7","s8"],
+    "events" : [ 
+        {
+            "event" : { "name" : "e-p2" },
+            "nextConfiguration" : ["s5","s6","s9","s10"]
+        }
+
+    ]
+}
+
+
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test2.scxml
+++ b/statifier-ex/test/fixtures/scxml/parallel/test2.scxml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- nested orthogonality 
+initial configuration: [s3,s4,s7,s8]
+after event t: [s5,s6,s9,s10]
+-->
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0">
+
+    <parallel id="p1">
+        <state id="s1" initial="p2">
+            <parallel id="p2">
+                <state id="s3"/>
+
+                <state id="s4"/>
+
+                <transition target="p3" event="e-p2"/>
+            </parallel>
+
+            <parallel id="p3">
+                <state id="s5"/>
+
+                <state id="s6"/>
+            </parallel>
+
+        </state>
+
+        <state id="s2" initial="p4">
+            <parallel id="p4">
+                <state id="s7"/>
+
+                <state id="s8"/>
+
+                <transition target="p5" event="e-p2"/>
+            </parallel>
+
+            <parallel id="p5">
+                <state id="s9"/>
+
+                <state id="s10"/>
+            </parallel>
+        </state>
+
+    </parallel>
+
+</scxml>
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test3.json
+++ b/statifier-ex/test/fixtures/scxml/parallel/test3.json
@@ -1,0 +1,15 @@
+{
+    "initialConfiguration" : ["s3.1","s4","s7","s8"],
+    "events" : [ 
+        {
+            "event" : { "name" : "t" },
+            "nextConfiguration" : ["s3.2","s4","s9","s10"]
+        }
+
+    ]
+}
+
+
+
+
+

--- a/statifier-ex/test/fixtures/scxml/parallel/test3.scxml
+++ b/statifier-ex/test/fixtures/scxml/parallel/test3.scxml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+   Copyright 2011-2012 Jacob Beard, INFICON, and other SCION contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-->
+<!-- nested orthogonality 
+initial configuration: [s3.1,s4,s7,s8]
+after event t: [s3.2,s4,s9,s10]
+-->
+<scxml
+    datamodel="ecmascript"
+    xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="p1">
+
+    <parallel id="p1">
+        <state id="s1" initial="p2">
+            <parallel id="p2">
+                <state id="s3" initial="s3.1">
+                    <state id="s3.1">
+                        <transition target="s3.2" event="t"/>
+                    </state>
+
+                    <state id="s3.2"/>
+                </state>
+
+                <state id="s4">
+                </state>
+
+            </parallel>
+
+            <parallel id="p3">
+                <state id="s5">
+                </state>
+
+                <state id="s6">
+                </state>
+            </parallel>
+
+        </state>
+
+        <state id="s2" initial="p4">
+            <parallel id="p4">
+                <state id="s7">
+                </state>
+
+                <state id="s8">
+                </state>
+
+                <transition target="p5" event="t"/>
+            </parallel>
+
+            <parallel id="p5">
+                <state id="s9">
+                </state>
+
+                <state id="s10">
+                </state>
+            </parallel>
+        </state>
+
+    </parallel>
+
+</scxml>
+

--- a/statifier-ex/test/scxml/basic_test.exs
+++ b/statifier-ex/test/scxml/basic_test.exs
@@ -1,0 +1,8 @@
+defmodule BasicTest do
+  use ExUnit.Case
+  import MachineHelpers
+
+  test_machines "basic", "basic0"
+  test_machines "basic", "basic1"
+  test_machines "basic", "basic2"
+end

--- a/statifier-ex/test/scxml/hierarchy_test.exs
+++ b/statifier-ex/test/scxml/hierarchy_test.exs
@@ -1,0 +1,8 @@
+defmodule HierarchyTest do
+  use ExUnit.Case
+  import MachineHelpers
+
+  test_machines "hierarchy", "hier0"
+  test_machines "hierarchy", "hier1"
+  test_machines "hierarchy", "hier2"
+end

--- a/statifier-ex/test/scxml/parallel_test.exs
+++ b/statifier-ex/test/scxml/parallel_test.exs
@@ -1,0 +1,9 @@
+defmodule ParallelTest do
+  use ExUnit.Case
+  import MachineHelpers
+
+  test_machines "parallel", "test0"
+  #test_machines "parallel", "test1"
+  #test_machines "parallel", "test2"
+  #test_machines "parallel", "test3"
+end

--- a/statifier-ex/test/statifier/scxml_test.exs
+++ b/statifier-ex/test/statifier/scxml_test.exs
@@ -1,0 +1,69 @@
+defmodule Statifier.ScxmlTest do
+  use ExUnit.Case
+
+  test "parses basic0" do
+    scxml_path = "./test/fixtures/scxml/basic/basic0.scxml"
+    {:ok, xmldoc} = File.read Path.expand scxml_path
+
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+
+    assert %{
+      initial: "a",
+      states: [
+        %{ id: "a", initial: ""}
+      ]
+    } = statechart.root
+  end
+
+  test "parses basic1" do
+    scxml_path = "./test/fixtures/scxml/basic/basic1.scxml"
+    {:ok, xmldoc} = File.read Path.expand scxml_path
+
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+
+    assert %{
+      states: [
+        %{ id: "a", transitions: [
+          %{ event: "t", target: "b" }
+        ]},
+        %{ id: "b", transitions: []}
+      ]
+    } = statechart.root
+  end
+
+  test "parses basic2" do
+    scxml_path = "./test/fixtures/scxml/basic/basic2.scxml"
+    {:ok, xmldoc} = File.read Path.expand scxml_path
+
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+
+    assert %{
+      states: [
+        %{ id: "a", transitions: [
+          %{ event: "t", target: "b" }
+        ]},
+        %{ id: "b", transitions: [
+          %{ event: "t2", target: "c" }
+        ]},
+        %{ id: "c" }
+      ]
+    } = statechart.root
+  end
+
+  test "parses parallel0" do
+    scxml_path = "./test/fixtures/scxml/parallel/test0.scxml"
+    {:ok, xmldoc} = File.read Path.expand scxml_path
+
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+
+    assert %{
+      states: [
+        %{ id: "p", type: "parallel", states: [
+          %{ id: "a" },
+          %{ id: "b" }
+        ]}
+      ]
+    } = statechart.root
+  end
+end
+

--- a/statifier-ex/test/statifier/statechart_test.exs
+++ b/statifier-ex/test/statifier/statechart_test.exs
@@ -1,0 +1,11 @@
+defmodule Statifier.StatechartTest do
+  use ExUnit.Case
+
+  test "builds a statechart from basic0" do
+    scxml_path = "./test/fixtures/scxml/basic/basic0.scxml"
+    {:ok, xmldoc} = File.read Path.expand scxml_path
+    statechart = Statifier.Scxml.parse_statechart xmldoc
+
+    assert 1 == length(statechart.root.states)
+  end
+end

--- a/statifier-ex/test/statifier_test.exs
+++ b/statifier-ex/test/statifier_test.exs
@@ -1,0 +1,5 @@
+defmodule StatifierTest do
+  use ExUnit.Case
+  doctest Statifier
+
+end

--- a/statifier-ex/test/test_helper.exs
+++ b/statifier-ex/test/test_helper.exs
@@ -1,0 +1,28 @@
+ExUnit.start()
+
+defmodule MachineHelpers do
+  defmacro test_machines(folder, file) do
+    quote do
+      test "conforms to SCXML test #{unquote(folder)} - #{unquote(file)}" do
+        folder = unquote(folder)
+        file = unquote(file)
+        scxml_path = "./test/fixtures/scxml/#{folder}/#{file}.scxml"
+        test_path = "./test/fixtures/scxml/#{folder}/#{file}.json"
+        {:ok, test_contents} = File.read Path.expand test_path
+        {:ok, test_config} = Poison.decode test_contents
+
+        machine = Statifier.machine_from_file(scxml_path)
+        configuration_literal = machine
+          |> Statifier.Machine.configuration_literal
+
+        assert configuration_literal == test_config["initialConfiguration"]
+
+        Enum.reduce(test_config["events"], machine, fn test_case, acc ->
+          new_machine = acc |> Statifier.Machine.send(test_case["event"]["name"])
+          assert (new_machine |> Statifier.Machine.configuration_literal) == test_case["nextConfiguration"]
+          new_machine
+        end)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds the statifier-ex folder with the contents coming from the
github.com/riddler/statifier-ex repo.

This collapses all the history from 27 August 2019 to 30 October 2019
into a single commit.

Closes #10