### PR TITLE
Adds spec folder

### DIFF
--- a/spec/01_basic/01_simple_single_state.scxml
+++ b/spec/01_basic/01_simple_single_state.scxml
@@ -1,0 +1,13 @@
+
+<?xmlencoding="UTF-8" version="1.0"?>
+<!--
+# Test YAML
+tests:
+- name: Simple Single State
+  verify:
+    configuration:
+    - greeting
+-->
+<scxml version="1.0" xmlns="http://www.w3.org/2005/07/scxml">
+    <state id="greeting"/>
+</scxml>

--- a/spec/01_basic/01_simple_single_state.yaml
+++ b/spec/01_basic/01_simple_single_state.yaml
@@ -1,0 +1,9 @@
+---
+statechart:
+  states:
+  - id: greeting
+tests:
+- name: Simple Single State
+  verify:
+    configuration:
+    - greeting

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,46 @@
+# Statifier Specification
+
+Statifier is an interpreter for executing [Statecharts][statecharts_github_io].
+This outlines the specification for Statifier based on the [SCXML Algorithm for SCXML Interpretation].
+Statifier uses terminology defined there.
+
+The specification is broken up into [SCXML documents][scxml_conforming_documents].
+
+Example:
+
+```xml
+<?xmlencoding="UTF-8" version="1.0"?>
+<!--
+# Test YAML
+tests:
+- name: Simple Single State
+  verify:
+    configuration:
+    - greeting
+-->
+<scxml version="1.0" xmlns="http://www.w3.org/2005/07/scxml">
+    <state id="greeting"/>
+</scxml>
+```
+
+These tests are also provided as a YAML document.
+
+Example:
+
+```yaml
+---
+statechart:
+  states:
+  - id: greeting
+tests:
+- name: Simple Single State
+  verify:
+    configuration:
+    - greeting
+```
+
+These specification define the statechart and a test to verify the initial configuration.
+
+[statecharts_github_io]: https://statecharts.github.io/
+[scxml_interpretation]: https://www.w3.org/TR/scxml/#AlgorithmforSCXMLInterpretation
+[scxml_conforming_documents]: https://www.w3.org/TR/scxml/#ConformingDocuments


### PR DESCRIPTION
This adds a README to the spec folder to provide information about the
purpose of files contained there. This folder will define the full
specification for the Statifier library.
 
This also adds the first specs around a simple single state Statechart.

Closes #3