### PR TITLE
Add SCXML and YAML Codecs

### DIFF
--- a/impl/ex/lib/codec/codec.ex
+++ b/impl/ex/lib/codec/codec.ex
@@ -1,0 +1,12 @@
+defmodule Statifier.Codec do
+  @moduledoc """
+  Codecs parse statechart definitions into valid `Statifier.Schema`s
+
+  Buil in Codecs:
+  * scxml - `Statifier.Codec.SCXML`
+  * yaml - `Statifier.Codec.YAML`
+  """
+  alias Statifier.Schema
+
+  @callback parse(Path.t()) :: {:ok, Schema.t()} | {:error, any()}
+end

--- a/impl/ex/lib/codec/scxml.ex
+++ b/impl/ex/lib/codec/scxml.ex
@@ -1,0 +1,134 @@
+defmodule Statifier.Codec.SCXML do
+  @moduledoc """
+  SCXML (State Chart extensible Markup Language) codec
+
+  SCXML specification: https://www.w3.org/TR/scxml/
+
+  An SCXML codec is one that can convert a scxml document from xml format
+  to a native `Statifier.Schema`.
+  """
+  import Statifier.Codec.SCXML.Helpers
+  alias Statifier.Schema
+  alias Statifier.Schema.{Root, State, Transition}
+
+  @behaviour Statifier.Codec
+
+  @impl Statifier.Codec
+  @doc """
+  Parses SCXML into a `Statifier.Schema`
+  """
+  def parse(scxml_document) do
+    scxml_document
+    # There really isn't a meaningful `event_state` we can put here
+    # until we encounter the scxml element
+    |> :xmerl_sax_parser.file(event_fun: &process_event/3, event_state: nil)
+    |> case do
+      {:ok, schema, ""} ->
+        {:ok, schema}
+
+      other ->
+        other
+    end
+  end
+
+  ###############################################
+  # scxml Element processing
+  ###############################################
+
+  # The true start of walking the xml
+  defp process_event(
+         {:startElement, _uri, 'scxml', _qualified_name, attributes},
+         _location,
+         nil
+       ) do
+    # TODO: we need to handle more attributes (version, datamodel, etc)
+    attributes = extract_attributes(attributes, ~w(initial name))
+
+    Schema.new(Root.new(attributes))
+  end
+
+  ###############################################
+  # state Element processing
+  ###############################################
+
+  # Anytime we encounter a state element we should move down to the children of
+  # the current element to add it. See the `:endElement` event of a state
+  # element to see us move back up.
+  defp process_event(
+         {:startElement, _uri, 'state', _qualified_name, attributes},
+         _location,
+         schema
+       ) do
+    attributes = extract_attributes(attributes, ~w(initial id))
+
+    state = State.new(attributes)
+
+    Schema.add_substate(schema, state)
+  end
+
+  # Anytime we encounter the end of a state we can move back up to our parent
+  # We also know that we are never going to look at this state elements children
+  # so we can reset the current level to get the scema ready for its initial use
+  defp process_event(
+         {:endElement, _uri, 'state', _qualified_name},
+         _location,
+         schema
+       ) do
+    Schema.rparent_state(schema)
+  end
+
+  ###############################################
+  # parallel Element processing
+  ###############################################
+
+  defp process_event(
+         {:startElement, _uri, 'parallel', _qualified_name, attributes},
+         _location,
+         schema
+       ) do
+    attributes =
+      extract_attributes(attributes, ~w(id))
+      |> Map.put(:parallel, true)
+
+    parallel = State.new(attributes)
+
+    Schema.add_substate(schema, parallel)
+  end
+
+  # Anytime we encounter the end of a parallel we can move back up to our parent
+  # We also know that we are never going to look at this elements children so we
+  # reset the current level to get the scema ready for its initial use
+  defp process_event(
+         {:endElement, _uri, 'parallel', _qualified_name},
+         _location,
+         schema
+       ) do
+    Schema.rparent_state(schema)
+  end
+
+  ###############################################
+  # transition Element processing
+  ###############################################
+
+  defp process_event(
+         {:startElement, _uri, 'transition', _qualified_name, attributes},
+         _location,
+         schema
+       ) do
+    attributes = extract_attributes(attributes, ~w(cond target event))
+
+    transition = Transition.new(attributes)
+
+    Schema.add_transition(schema, transition)
+  end
+
+  ###############################################
+  # unrecognized element processing
+  # TODO: We probably need to throw errors here
+  # This could mean that the scxml is invalid
+  ###############################################
+
+  defp process_event(_event, _location, state) do
+    state
+  end
+end

--- a/impl/ex/lib/codec/scxml/helpers.ex
+++ b/impl/ex/lib/codec/scxml/helpers.ex
@@ -1,0 +1,37 @@
+defmodule Statifier.Codec.SCXML.Helpers do
+  @type xml_attribute :: {
+          uri :: [],
+          location :: [],
+          attribute_name :: charlist(),
+          attribute_value :: charlist()
+        }
+
+  @type xml_attributes :: [xml_attribute()]
+
+  @spec extract_attributes(xml_attributes(), nonempty_list(String.t())) :: Map.t()
+  @doc """
+  Converts from an xml attributes list to a map of wanted params.
+
+  Example:
+
+    iex> Statifier.Codec.SCXML.Helpers.extract_attributes([{[], [], 'attribute', 'value'}], ~w(attribute))
+    %{attribute: "value"}
+
+  """
+  def extract_attributes(attributes, needed_attributes) do
+    # Convert needed into MapSet for little speed boost to looking up keys
+    needed_attributes = MapSet.new(needed_attributes)
+
+    attributes
+    |> Enum.reduce(%{}, fn {_uri, _location, name, value}, transformed ->
+      # Convert charlist values to strings
+      [name, value] = Enum.map([name, value], &to_string/1)
+
+      if MapSet.member?(needed_attributes, name) do
+        Map.put(transformed, String.to_atom(name), value)
+      else
+        transformed
+      end
+    end)
+  end
+end

--- a/impl/ex/lib/codec/yaml.ex
+++ b/impl/ex/lib/codec/yaml.ex
@@ -1,0 +1,89 @@
+defmodule Statifier.Codec.YAML do
+  @moduledoc """
+  YAML State chart definition codec.
+
+  An YAML codec is one that can convert a yaml to a native `Statifier.Schema`.
+  """
+
+  import Statifier.Codec.YAML.Helpers
+  alias Statifier.Codec.YAML.Walker
+  alias Statifier.Schema
+  alias Statifier.Schema.{Root, State, Transition}
+
+  @behaviour Statifier.Codec
+
+  @impl Statifier.Codec
+  def parse(yaml_document) do
+    case Walker.walk(yaml_document, event_state: nil, event_fun: &process_event/2) do
+      {:error, _reason} = error ->
+        error
+
+      schema ->
+        {:ok, schema}
+    end
+  end
+
+  ###############################################
+  # Statechart Element processing
+  ###############################################
+
+  defp process_event({:start_element, "statechart", statechart}, nil) do
+    extract_attributes(statechart, %{"name" => :name})
+    |> Map.merge(extract_attributes(Map.get(statechart, "root"), %{"initial" => :initial}))
+    |> Root.new()
+    |> Schema.new()
+  end
+
+  ###############################################
+  # state Element processing
+  ###############################################
+
+  defp process_event({:start_element, "states", state}, schema) do
+    params =
+      state
+      |> extract_attributes(%{
+        "name" => :id,
+        "transitions" => :transitions,
+        "initial" => :initial
+      })
+
+    transitions =
+      Map.get(params, :transitions, [])
+      |> Enum.map(fn transition ->
+        transition
+        |> extract_attributes(%{"cond" => :cond, "target" => :target, "event" => :event})
+        |> Transition.new()
+      end)
+
+    state =
+      params
+      |> Map.put(:transitions, transitions)
+      |> State.new()
+
+    Schema.add_substate(schema, state)
+  end
+
+  defp process_event({:end_element, "states"}, schema) do
+    Schema.rparent_state(schema)
+  end
+
+  ###############################################
+  # parallel Element processing
+  ###############################################
+
+  defp process_event({:start_element, "parallel", parallel}, schema) do
+    parallel =
+      parallel
+      |> extract_attributes(%{"name" => :id, "initial" => :initial})
+      |> Map.put(:parallel, true)
+      |> State.new()
+
+    Schema.add_substate(schema, parallel)
+  end
+
+  defp process_event({:end_element, "parallel"}, schema) do
+    Schema.rparent_state(schema)
+  end
+
+  defp process_event(_, schema), do: schema
+end

--- a/impl/ex/lib/codec/yaml/helpers.ex
+++ b/impl/ex/lib/codec/yaml/helpers.ex
@@ -1,0 +1,28 @@
+defmodule Statifier.Codec.YAML.Helpers do
+  @moduledoc """
+  Helpers for transforming yaml elements
+  """
+
+  @spec extract_attributes(node :: %{optional(String.t()) => any()}, %{
+          optional(String.t()) => :atom
+        }) :: %{optional(:atom) => any()}
+  @doc """
+  Returns a map of attributes from `node` that are found in `mappings`,
+  transforming keys into atoms specified in `mappings`
+
+  # Examples:
+
+    iex> extract_attributes(%{"id" => "an identifier"}, %{"id" => :name})
+    %{name: "an identifier"}
+  """
+  def extract_attributes(node, mappings) do
+    mappings
+    |> Enum.reduce(%{}, fn {key, mapping}, attributes ->
+      if Map.has_key?(node, key) do
+        Map.put(attributes, mapping, Map.get(node, key))
+      else
+        attributes
+      end
+    end)
+  end
+end

--- a/impl/ex/lib/codec/yaml/walker.ex
+++ b/impl/ex/lib/codec/yaml/walker.ex
@@ -1,0 +1,77 @@
+defmodule Statifier.Codec.YAML.Walker do
+  @moduledoc """
+  Helper for walking a YAML document and dispatching events to a handler to
+  process elements as they are found.
+
+  See `:xmerl_sax_parser` for reference implementation this is emulating.
+  """
+
+  @type element :: %{optional(String.t()) => any()}
+
+  @typedoc """
+  The initital state passed to `event_fun`
+  """
+  @type event_state :: any()
+
+  @typedoc """
+  This function will be called with events everytime a new map or list is 
+  encountered while walking the document. It is expected to return the
+  `event_state` for the next event.
+  """
+  @type event_fun :: function()
+
+  @type event ::
+          {:start_element, list_or_map_name :: String.t(), attributes :: element()}
+          | {:end_element, list_or_map_name :: String.t()}
+
+  @type walker_opts :: [event_state: event_state(), event_fun: function()]
+
+  @spec walk(Path.t(), walker_opts()) :: {:ok, any()} | {:error, any()}
+  @doc """
+  Takes in a file and starts processing it by calling `event_fun` defined
+  in `opts` with each start and end of processing maps or lists.
+  """
+  def walk(file, opts) do
+    initial_state = Keyword.get(opts, :event_state, nil)
+    processor = Keyword.get(opts, :event_fun)
+
+    case YamlElixir.read_from_file(file) do
+      {:ok, yaml} ->
+        do_walk(yaml, {processor, initial_state})
+
+      error ->
+        error
+    end
+  end
+
+  defp do_walk(yaml, {processor, state}) when is_map(yaml) do
+    Enum.reduce(
+      yaml,
+      state,
+      fn
+        # New map we are seeing
+        {key, map}, state when is_map(map) ->
+          # starting element
+          state = processor.({:start_element, key, map}, state)
+          # Walk it recursively
+          state = do_walk(map, {processor, state})
+          # Done walking element
+          processor.({:end_element, key}, state)
+
+        # new list of possible elements
+        {key, list}, state when is_list(list) ->
+          Enum.reduce(list, state, fn element, state ->
+            # Starting processing list
+            state = processor.({:start_element, key, element}, state)
+            # Walk it recursively
+            state = do_walk(element, {processor, state})
+            # Done walking element
+            processor.({:end_element, key}, state)
+          end)
+
+        {_key, _non_list_or_map}, state ->
+          state
+      end
+    )
+  end
+end

--- a/impl/ex/lib/schema/root.ex
+++ b/impl/ex/lib/schema/root.ex
@@ -1,0 +1,22 @@
+defmodule Statifier.Schema.Root do
+  @moduledoc """
+  The Root of a state machine
+
+  The initial state of the machine is determined by the `initial` property or
+  the first child state of the machine.
+  """
+  alias Statifier.Schema.State
+
+  # TODO: Need to add context/datamodel eventually
+  @type t :: %__MODULE__{
+          name: String.t() | nil,
+          initial: State.state_identifier()
+        }
+
+  defstruct initial: nil, name: nil
+
+  @doc """
+  Creates a new Root node.
+  """
+  def new(params), do: struct!(__MODULE__, params)
+end

--- a/impl/ex/lib/schema/schema.ex
+++ b/impl/ex/lib/schema/schema.ex
@@ -1,0 +1,143 @@
+defmodule Statifier.Schema do
+  @moduledoc """
+  A compiled and parsed state chart definition
+
+  The Schema Struct:
+
+  The fields of a Schema should not be adjusted manually but are publicly
+  available to read. They are as follows:
+
+  * `initial_configuration` - the initial configuration of the machine (root)
+  * `state_identifiers` - collection of all the known state identifiers
+  * `valid?` - Whether the parsed definition led to a valid schema
+  * `transitions` - All the states that transitions move to
+  """
+  alias Statifier.Schema
+  alias Statifier.Schema.{Root, State, Transition, ZTree}
+
+  @type t :: %__MODULE__{
+          initial_configuration: Schema.ZTree.t(),
+          state_identifiers: MapSet.t(State.state_identifier()),
+          valid?: boolean(),
+          transitions: MapSet.t(State.state_identifier())
+        }
+
+  defstruct initial_configuration: nil,
+            state_identifiers: MapSet.new(),
+            valid?: false,
+            transitions: MapSet.new()
+
+  @doc """
+  Creates a new schema
+  """
+  def new(%Root{} = root) do
+    %__MODULE__{
+      initial_configuration: ZTree.root(root)
+    }
+  end
+
+  def current_state(%__MODULE__{initial_configuration: initial_configuration}) do
+    ZTree.focus(initial_configuration)
+  end
+
+  @doc """
+  Moves up to the parent state of current focused stat node.
+
+  Also resets children list so that when going back into children the first
+  child would be visited.
+  """
+  def rparent_state(%__MODULE__{initial_configuration: configuration} = schema) do
+    configuration =
+      case ZTree.rparent(configuration) do
+        {:ok, configuration} -> configuration
+        _ -> configuration
+      end
+
+    %__MODULE__{
+      schema
+      | initial_configuration: configuration,
+        valid?: check_validity(schema)
+    }
+  end
+
+  @doc """
+  Adds a new substate to the current focused state node in configuration
+  """
+  def add_substate(%__MODULE__{initial_configuration: configuration} = schema, %State{} = state) do
+    state_identifiers = MapSet.put(schema.state_identifiers, state.id)
+
+    # Add all transitions with targets to our transitions set
+    transitions =
+      Enum.reduce(state.transitions, schema.transitions, fn transition, acc ->
+        if transition.target != nil do
+          MapSet.put(acc, transition.target)
+        else
+          acc
+        end
+      end)
+
+    configuration =
+      case ZTree.children(configuration) do
+        {:ok, configuration} ->
+          ZTree.insert_right(configuration, state)
+          |> ZTree.right!()
+
+        {:error, :cannot_make_move} ->
+          ZTree.insert_child(configuration, state)
+          |> ZTree.children!()
+      end
+
+    %__MODULE__{
+      schema
+      | initial_configuration: configuration,
+        transitions: transitions,
+        state_identifiers: state_identifiers,
+        valid?: check_validity(schema)
+    }
+  end
+
+  def add_transition(
+        %__MODULE__{transitions: transitions, initial_configuration: configuration} = schema,
+        %Transition{target: target} = transition
+      )
+      when not is_nil(target) do
+    state = ZTree.focus(configuration)
+
+    %__MODULE__{
+      schema
+      | transitions: MapSet.put(transitions, target),
+        initial_configuration:
+          ZTree.replace(configuration, State.add_transition(state, transition)),
+        valid?: check_validity(schema)
+    }
+  end
+
+  def add_transition(
+        %__MODULE__{initial_configuration: configuration} = schema,
+        %Transition{} = transition_without_target
+      ) do
+    state = ZTree.focus(configuration)
+
+    %__MODULE__{
+      schema
+      | initial_configuration:
+          ZTree.replace(configuration, State.add_transition(state, transition_without_target)),
+        valid?: check_validity(schema)
+    }
+  end
+
+  defp check_validity(%__MODULE__{
+         transitions: transitions,
+         initial_configuration: configuration,
+         state_identifiers: states
+       }) do
+    # all the checks we have to do for validity
+    [
+      # Are we at the root of our tree
+      ZTree.focus(configuration),
+      # Do all transitions move to known discovered states
+      MapSet.subset?(transitions, states)
+    ]
+    |> Enum.all?()
+  end
+end

--- a/impl/ex/lib/schema/state.ex
+++ b/impl/ex/lib/schema/state.ex
@@ -1,0 +1,134 @@
+defmodule Statifier.Schema.State do
+  @moduledoc """
+  A State node in a Schema tree
+
+  State nodes model the different states a state machine can transition to.
+  They optionally form a hierarchy where a state is a parent to other state
+  node(s). This hierarchy forms a lineage where when in a child state you are 
+  also in the parent state. The rules and behavior surrounding how child
+  states are entered is dependent on the `class` of the state node - see
+  "Classifications" section below.
+
+  ## The Statifier.Schema.State struct:
+
+  The public fields are:
+
+  * `id` - name by which state can be identified and transitioned to
+  * `parallel` - whether this node is a regular state or a parallel state
+  * `transitions` - all of the `Statifier.Schema.Transition`s of the state
+  * `on_enter` function to run when leaving state
+  * `on_exit` - function to run when leaving state
+
+  ## Classifictions
+
+  State nodes fall into one of two classification. They are either `parallel`
+  nodes or regular state nodes. A `parallel` node has two or more child states
+  and they all become activated when entering the parent state. Regular state
+  nodes can have 0 or more children. If they have more than one child only one
+  can be active at any one time.
+
+  Non parallel state nodes can be `atomic` or `compound`. An `atomic` stat is
+  one that does not have any child states. A compound state has one or more
+  child states. A `parallel` state by definition will always be a `compound`
+  state.
+
+  ### Examples
+
+  Classic Microwave (non parallel) example:
+
+  - microwave machine
+    - off state
+    - on state
+      - idle state
+      - cooking state
+
+  The above example does not contain any `parallel` state nodes. It does
+  contain two `compound` states. The top level machine which can be off or on,
+  and the on state which is either idle or cooking. Lastly, it contains three
+  `atomic` states: off, idle, and cooking.
+
+  Parallel Microwave example:
+
+  - microwave machine
+    - parallel (oven state)
+      - engine state
+        - off state
+        - on state
+          - cooking
+          - idle
+      - door state
+        - closed state
+        - open state
+
+  This example does contain a `parallel` which maintains the state of the door
+  and the state of the engine of the microwave. When in the oven state you are
+  also in the door state and the engine state. Here there are four `compound`
+  states: oven, engine, on, and door. For `atomic` states there are five: off,
+  cooking, idle, closed, and open.
+  """
+  alias Statifier.Schema.Transition
+
+  @typedoc """
+  State identifiers are used to name a state and give an identifier that
+  `Statifier.Schema.Transition` use as their target parameter in order to move
+  to a state.
+  """
+  @type state_identifier :: String.t()
+
+  # TODO: figure out how we want to represent on_enter/exit
+  @type t :: %__MODULE__{
+          id: state_identifier(),
+          parallel: boolean(),
+          transitions: [Transition.t()],
+          on_exit: String.t() | nil,
+          on_entry: String.t() | nil
+        }
+
+  defstruct id: nil, parallel: false, transitions: [], on_entry: nil, on_exit: nil
+
+  @spec new(Map.t()) :: t()
+  @doc """
+  Creates a new `Statifier.Schema.State`
+
+  If no `id` is supplied in params then one will be generated. 
+
+  ## Options
+
+  * `id` - state identifier
+  * `initial` - initial state (only for compound states)
+  * `parallel` - is this a parallel state node
+  # TODO: These are not implemented yet
+  * `on_enter` - function to execute when entering state
+  * `on_exit` - function to execute when exiting state
+
+  """
+  def new(params) do
+    dynamic_defaults = %{
+      id: "TODO: make this random?"
+    }
+
+    params = Map.merge(dynamic_defaults, params)
+    state = struct(__MODULE__, params)
+
+    # If supplied an initial convert it to a transition with no cond or event
+    if Map.has_key?(params, :initial) do
+      # TODO: would the initial transition be an internal?
+      add_transition(state, Transition.new(target: Map.get(params, :initial), type: :internal))
+    else
+      state
+    end
+  end
+
+  @doc """
+  Adds a transition to a state.
+
+  This should only be used as a helper to build a state node, and not doing a
+  running machine since state machines need to be deterministic.
+  """
+  def add_transition(%__MODULE__{} = state, %Transition{} = transition) do
+    %__MODULE__{
+      state
+      | transitions: Enum.concat(state.transitions, [transition])
+    }
+  end
+end

--- a/impl/ex/lib/schema/transition.ex
+++ b/impl/ex/lib/schema/transition.ex
@@ -1,0 +1,31 @@
+defmodule Statifier.Schema.Transition do
+  @moduledoc """
+  Defines transitions between states of a machine.
+
+  Transitions must specify a target state they are transitioning to and usually
+  occur by internal or external events. Transitions can also optionally specify
+  a condition predicate that must also be true in order to trigger a transition.
+  This allows multiple transitions to specify the same event and transition to
+  different target states based on condition.
+  """
+  alias Statifier.Schema.State
+
+  @type event :: :internal | :external
+  @type predicate_string :: String.t()
+
+  @type t :: %__MODULE__{
+          event: String.t() | nil,
+          cond: predicate_string() | nil,
+          target: State.state_identifier()
+        }
+
+  defstruct event: nil, cond: nil, target: nil, type: :external
+
+  @spec new(Map.t()) :: t()
+  @doc """
+  Creates a new `Statifier.Schema.Transition`
+  """
+  def new(params) do
+    struct!(__MODULE__, params)
+  end
+end

--- a/impl/ex/lib/statifier.ex
+++ b/impl/ex/lib/statifier.ex
@@ -1,0 +1,22 @@
+defmodule Statifier do
+  def parse() do
+    :statifier
+    |> :code.priv_dir()
+    |> Path.join("scxml/microwave.scxml")
+    |> Statifier.Codec.SCXML.parse()
+  end
+
+  def parse(file) do
+    codec =
+      if String.ends_with?(file, ".yaml") do
+        Statifier.Codec.YAML
+      else
+        Statifier.Codec.SCXML
+      end
+
+    :statifier
+    |> :code.priv_dir()
+    |> Path.join(file)
+    |> codec.parse()
+  end
+end

--- a/impl/ex/mix.exs
+++ b/impl/ex/mix.exs
@@ -21,8 +21,7 @@ defmodule Statifier.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:yaml_elixir, "~> 2.5"}
     ]
   end
 end

--- a/impl/ex/mix.lock
+++ b/impl/ex/mix.lock
@@ -1,0 +1,4 @@
+%{
+  "yamerl": {:hex, :yamerl, "0.8.0", "8214cfe16bbabe5d1d6c14a14aea11c784b9a21903dd6a7c74f8ce180adae5c7", [:rebar3], [], "hexpm", "010634477bf9c208a0767dcca89116c2442cf0b5e87f9c870f85cd1c3e0c2aab"},
+  "yaml_elixir": {:hex, :yaml_elixir, "2.5.0", "45de762be6d75fa5a8b5f44ddff8c30f64c26526eab5b1d72e36d616007b7796", [:mix], [{:yamerl, "~> 0.7", [hex: :yamerl, repo: "hexpm", optional: false]}], "hexpm", "80fe4e43f05582f2a90f2dcd73fc6171fbd65f2e6836f71fe4ce2154ef358c36"},
+}

--- a/impl/ex/priv/scxml/microwave-parallel.scxml
+++ b/impl/ex/priv/scxml/microwave-parallel.scxml
@@ -1,0 +1,66 @@
+<?xml version="1.0"?>
+<scxml xmlns="http://www.w3.org/2005/07/scxml"
+       version="1.0"
+       datamodel="ecmascript"
+       initial="oven"> 
+
+  <!-- trivial 5 second microwave oven example -->
+  <!-- using parallel and In() predicate -->
+  <datamodel>
+    <data id="cook_time" expr="5"/>
+    <data id="door_closed" expr="true"/>
+    <data id="timer" expr="0"/>
+  </datamodel>
+
+  <parallel id="oven">
+
+    <!-- this region tracks the microwave state and timer -->
+    <state id="engine">
+    <initial>
+      <transition target="off"/>
+      </initial>
+
+      <state id="off">
+        <!-- off state -->
+        <transition event="turn.on" target="on"/>
+      </state>
+      
+      <state id="on">
+      <initial>
+        <transition target="idle"/>
+        </initial>
+        
+         <!-- on/pause state -->
+        
+        <transition event="turn.off" target="off"/>
+        <transition cond="timer &gt;= cook_time" target="off"/>
+        
+        <state id="idle">
+          <transition cond="In('closed')" target="cooking"/>
+        </state>
+        
+        <state id="cooking">
+          <transition cond="In('open')" target="idle"/>
+
+          <!-- a 'time' event is seen once a second -->
+          <transition event="time">
+            <assign location="timer" expr="timer + 1"/>
+          </transition>
+        </state>
+      </state>
+    </state>
+
+    <!-- this region tracks the microwave door state -->
+    <state id="door">
+      <initial>
+        <transition target="closed"/>
+      </initial>
+      <state id="closed">
+        <transition event="door.open" target="open"/>
+      </state>
+      <state id="open">
+        <transition event="door.close" target="closed"/>
+       </state>
+    </state>
+  </parallel>
+</scxml>

--- a/impl/ex/priv/scxml/microwave.scxml
+++ b/impl/ex/priv/scxml/microwave.scxml
@@ -1,0 +1,50 @@
+<?xml version="1.0"?>
+<scxml xmlns="http://www.w3.org/2005/07/scxml"
+       version="1.0"
+       datamodel="ecmascript"
+       initial="off">
+
+  <!--  trivial 5 second microwave oven example -->
+  <datamodel>
+    <data id="cook_time" expr="5"/>
+    <data id="door_closed" expr="true"/>
+    <data id="timer" expr="0"/>
+  </datamodel>
+
+  <state id="off">
+    <!-- off state -->
+    <transition event="turn.on" target="on"/>
+  </state>
+
+  <state id="on">
+    <initial>
+        <transition target="idle"/>
+    </initial>
+    <!-- on/pause state -->
+
+    <transition event="turn.off" target="off"/>
+    <transition cond="timer &gt;= cook_time" target="off"/>
+
+    <state id="idle">
+      <!-- default immediate transition if door is shut -->
+      <transition cond="door_closed" target="cooking"/>
+      <transition event="door.close" target="cooking">
+        <assign location="door_closed" expr="true"/>
+        <!-- start cooking -->
+      </transition>
+    </state>
+
+    <state id="cooking">
+      <transition event="door.open" target="idle">
+        <assign location="door_closed" expr="false"/>
+      </transition>
+
+      <!-- a 'time' event is seen once a second -->
+      <transition event="time">
+        <assign location="timer" expr="timer + 1"/>
+      </transition>
+    </state>
+
+  </state>
+
+</scxml>

--- a/impl/ex/priv/yaml/microwave-parallel.yaml
+++ b/impl/ex/priv/yaml/microwave-parallel.yaml
@@ -1,0 +1,49 @@
+statechart:
+  name: Microwave controller
+  # TODO: Implement DATAMODEL
+  preamble: |
+    POWER_VALUES = [300, 600, 900, 1200, 1500]
+    POWER_DEFAULT = 2  # 900W
+    MAXPOWER = 3  # 1200W
+  root:
+    initial: oven
+    parallel:
+    - name: engine
+      initial: off
+      states:
+      - name: off
+        transitions: 
+        - event: turn.on
+          target: on
+      - name: on
+        initial: idle
+        transitions:
+        - event: turn.off
+          target: off
+        - cond: timer
+          target: off
+        states:
+        - name: idle
+          transitions:
+          - cond: In('closed')
+            target: cooking
+        - name: cooking
+          transitions:
+          - cond: In('open')
+            target: idle
+            # TODO: implement assigning to datamodel
+            assign: "..."
+          - event: time
+    - name: door
+      initial: closed
+      states:
+      - name: closed
+        transitions:
+        - event: door.open
+          target: open
+        - event: door.close
+          target: closed
+      - name: open
+        transitions:
+        - event: door.close
+          target: closed

--- a/impl/ex/priv/yaml/microwave.yaml
+++ b/impl/ex/priv/yaml/microwave.yaml
@@ -1,0 +1,35 @@
+statechart:
+  name: Microwave (non parallel)
+  root:
+    initial: off
+    states:
+    - name: off
+      transitions:
+        - event: turn.on
+          target: on
+    - name: on
+      initial: idle
+      transitions:
+      - event: turn.off
+        target: off
+      - cond: "timer >= cooktime"
+        target: off
+      states:
+      - name: idle
+        transitions:
+        - cond: door_closed
+          target: cooking
+        - event: door.close
+          target: cooking
+          # TODO: implement assigning to datamodel
+          assign: "..."
+      - name: cooking
+        transitions:
+        - event: door.open
+          target: idle
+          # TODO implement assigning to datamodel
+          assign: "..."
+        - event: time
+          # TODO: implement assigning to datamodel
+          assign: "..."
+

--- a/impl/ex/test/codec/scxml_test.exs
+++ b/impl/ex/test/codec/scxml_test.exs
@@ -1,0 +1,12 @@
+defmodule Statifier.Codec.SCXMLTest do
+  use ExUnit.Case, async: true
+  alias Statifier.Schema
+  alias Statifier.Codec.SCXML
+  doctest Statifier.Codec.SCXML.Helpers
+
+  @microwave Path.join(:code.priv_dir(:statifier), "scxml/microwave.scxml")
+
+  test "can produce valid schemas" do
+    assert {:ok, %Schema{valid?: true}} = SCXML.parse(@microwave)
+  end
+end

--- a/impl/ex/test/codec/yaml_test.exs
+++ b/impl/ex/test/codec/yaml_test.exs
@@ -1,0 +1,11 @@
+defmodule Statifier.Codec.YAMLTest do
+  use ExUnit.Case, async: true
+  alias Statifier.Schema
+  alias Statifier.Codec.YAML
+
+  @microwave Path.join(:code.priv_dir(:statifier), "yaml/microwave.yaml")
+
+  test "can produce valid schemas" do
+    assert {:ok, %Schema{valid?: true}} = YAML.parse(@microwave)
+  end
+end


### PR DESCRIPTION
Sorry there is a lot here but I figured I would just get everything cleaned up and off my machine.

This adds the yaml and scxml parsers. I did decide to change the name to Codec because it grew on me. The `Statifier.Schema` API is not perfect as of right now but I think it is good enough to move on. Really only people writing `Codec`s will care about how to work with the Schema so its basically an internal detail that we can clean up over time. I also plan in the future to add more tests to all of this when I start doing more of the machine api.