### PR TITLE
Add parse from string callback to Statifier.Codec

### DIFF
--- a/impl/ex/lib/codec/codec.ex
+++ b/impl/ex/lib/codec/codec.ex
@@ -8,5 +8,6 @@ defmodule Statifier.Codec do
   """
   alias Statifier.Schema
 
-  @callback parse(Path.t()) :: {:ok, Schema.t()} | {:error, any()}
+  @callback from_file(Path.t()) :: {:ok, Schema.t()} | {:error, any()}
+  @callback parse(String.t()) :: {:ok, Schema.t()} | {:error, any()}
 end

--- a/impl/ex/lib/codec/scxml.ex
+++ b/impl/ex/lib/codec/scxml.ex
@@ -15,13 +15,29 @@ defmodule Statifier.Codec.SCXML do
 
   @impl Statifier.Codec
   @doc """
-  Parses SCXML into a `Statifier.Schema`
+  Parses SCXML from a file path into a `Statifier.Schema`
   """
-  def parse(scxml_document) do
+  def from_file(scxml_document) do
     scxml_document
     # There really isn't a meaningful `event_state` we can put here
     # until we encounter the scxml element
     |> :xmerl_sax_parser.file(event_fun: &process_event/3, event_state: nil)
+    |> case do
+      {:ok, schema, ""} ->
+        {:ok, schema}
+
+      other ->
+        other
+    end
+  end
+
+  @impl Statifier.Codec
+  @doc """
+  Parses SCXML from a string into a `Statifier.Schema`
+  """
+  def parse(scxml) do
+    scxml
+    |> :xmerl_sax_parser.stream(event_fun: &process_event/3, event_state: nil)
     |> case do
       {:ok, schema, ""} ->
         {:ok, schema}

--- a/impl/ex/lib/codec/yaml.ex
+++ b/impl/ex/lib/codec/yaml.ex
@@ -13,13 +13,24 @@ defmodule Statifier.Codec.YAML do
   @behaviour Statifier.Codec
 
   @impl Statifier.Codec
-  def parse(yaml_document) do
-    case Walker.walk(yaml_document, event_state: nil, event_fun: &process_event/2) do
-      {:error, _reason} = error ->
-        error
+  def from_file(yaml_path) do
+    case YamlElixir.read_from_file(yaml_path) do
+      {:ok, yaml} ->
+        Walker.walk(yaml, event_state: nil, event_fun: &process_event/2)
 
-      schema ->
-        {:ok, schema}
+      error ->
+        error
+    end
+  end
+
+  @impl Statifier.Codec
+  def parse(yaml_string) do
+    case YamlElixir.read_from_string(yaml_string) do
+      {:ok, yaml} ->
+        Walker.walk(yaml, event_state: nil, event_fun: &process_event/2)
+
+      error ->
+        error
     end
   end
 

--- a/impl/ex/lib/codec/yaml/walker.ex
+++ b/impl/ex/lib/codec/yaml/walker.ex
@@ -26,22 +26,16 @@ defmodule Statifier.Codec.YAML.Walker do
 
   @type walker_opts :: [event_state: event_state(), event_fun: function()]
 
-  @spec walk(Path.t(), walker_opts()) :: {:ok, any()} | {:error, any()}
+  @spec walk(String.t(), walker_opts()) :: {:ok, any()} | {:error, any()}
   @doc """
-  Takes in a file and starts processing it by calling `event_fun` defined
+  Takes yaml string and starts processing it by calling `event_fun` defined
   in `opts` with each start and end of processing maps or lists.
   """
-  def walk(file, opts) do
+  def walk(yaml, opts) do
     initial_state = Keyword.get(opts, :event_state, nil)
     processor = Keyword.get(opts, :event_fun)
 
-    case YamlElixir.read_from_file(file) do
-      {:ok, yaml} ->
-        do_walk(yaml, {processor, initial_state})
-
-      error ->
-        error
-    end
+    do_walk(yaml, {processor, initial_state})
   end
 
   defp do_walk(yaml, {processor, state}) when is_map(yaml) do

--- a/impl/ex/lib/statifier.ex
+++ b/impl/ex/lib/statifier.ex
@@ -1,12 +1,12 @@
 defmodule Statifier do
-  def parse() do
+  def from_file() do
     :statifier
     |> :code.priv_dir()
     |> Path.join("scxml/microwave.scxml")
-    |> Statifier.Codec.SCXML.parse()
+    |> Statifier.Codec.SCXML.from_file()
   end
 
-  def parse(file) do
+  def from_file(file) do
     codec =
       if String.ends_with?(file, ".yaml") do
         Statifier.Codec.YAML
@@ -17,6 +17,6 @@ defmodule Statifier do
     :statifier
     |> :code.priv_dir()
     |> Path.join(file)
-    |> codec.parse()
+    |> codec.from_file()
   end
 end


### PR DESCRIPTION
Previously the `parse` callback was to parse from file. It has come up a
few times where being able to pass in a string would make testing things
easier rather than always from a file. This change moves the old `parse`
behaviour to a new callback `from_file` and makes the new `parse` take
its input as a string.

* Change `parse` to `from_file` in YAML and SCXML Codecs
* Add new `parse` implementation to YAML and SCXML Codecs
* Update temporary `Statifier` functions to `from_file` to match old use