### PR TITLE
Introduce Configuration Module

### DIFF
--- a/impl/ex/lib/configuration.ex
+++ b/impl/ex/lib/configuration.ex
@@ -1,0 +1,26 @@
+defmodule Statifier.Configuration do
+  @moduledoc """
+  A `Statifier.Configuration` maintains the complete set of states a machine
+  is in.
+
+  `Statifier.Configuration` is a tree like model to support a lineage of states
+  that are currently active. When a state is active all of it's parents are
+  also active.
+  """
+
+  import Statifier.Schema.ZTree
+  @type t :: ZTree.t()
+  @spec compound?(t()) :: boolean()
+  @doc """
+  Returns whether focused state of configuration is `compound`
+  """
+  def compound?(configuration) do
+    children?(configuration)
+  end
+
+  @spec atomic?(t()) :: boolean()
+  @doc """
+  Returns whether focused state of configuration is `atomic`
+  """
+  def atomic?(configuration), do: not compound?(configuration)
+end

--- a/impl/ex/test/configuration_test.exs
+++ b/impl/ex/test/configuration_test.exs
@@ -1,0 +1,41 @@
+defmodule Statifier.ConfigurationTest do
+  use ExUnit.Case, async: true
+  alias Statifier.Codec.YAML
+  alias Statifier.Configuration
+  alias Statifier.Schema.ZTree
+
+  describe "checking if a state node is compound or atomic" do
+    setup do
+      {:ok, %{initial_configuration: configuration}} = YAML.parse(~s/
+        statechart:
+          name: test
+          root:
+            states:
+              - name: compound
+                states:
+                  - name: nested1
+                  - name: nested2
+              - name: atomic
+      /)
+
+      {:ok, configuration: configuration}
+    end
+
+    test "is compound if node has substates", %{configuration: configuration} do
+      # Find compound child
+      configuration = ZTree.children!(configuration)
+      assert Configuration.compound?(configuration)
+
+      # move to atomic sibling
+      configuration = ZTree.right!(configuration)
+      refute Configuration.compound?(configuration)
+    end
+
+    test "is atomic if node has no substates", %{configuration: configuration} do
+      # navigate to atomic state
+      configuration = ZTree.children!(configuration) |> ZTree.right!()
+
+      assert Configuration.atomic?(configuration)
+    end
+  end
+end


### PR DESCRIPTION
This module will be the driving force behind calculating what the next
state configuration is going to be. It will also communicate back to the
machine any states that were entered/exited from doing the transitions
so that the machine can invoke their logic.

The first functions introduced here are `compound?` and `atomic?` which
will be used later in recursion to keep entering states until we have
entered atomic states on microstep.