### PR TITLE
Introduce final states

### DIFF
--- a/impl/ex/lib/codec/yaml.ex
+++ b/impl/ex/lib/codec/yaml.ex
@@ -55,8 +55,17 @@ defmodule Statifier.Codec.YAML do
       |> extract_attributes(%{
         "name" => :id,
         "transitions" => :transitions,
-        "initial" => :initial
+        "initial" => :initial,
+        "final" => :final
       })
+
+    # Set type of :final or :state
+    params =
+      if Map.get(params, :final) == true do
+        Map.put(params, :type, :final)
+      else
+        Map.put(params, :type, :state)
+      end
 
     transitions =
       Map.get(params, :transitions, [])
@@ -86,7 +95,7 @@ defmodule Statifier.Codec.YAML do
     parallel =
       parallel
       |> extract_attributes(%{"name" => :id, "initial" => :initial})
-      |> Map.put(:parallel, true)
+      |> Map.put(:type, :parallel)
       |> State.new()
 
     Schema.add_substate(schema, parallel)

--- a/impl/ex/priv/scxml/main.scxml
+++ b/impl/ex/priv/scxml/main.scxml
@@ -1,0 +1,206 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<!-- A wrapper state that contains all other states in this file
+- it represents the complete state machine --> 
+<scxml xmlns="http://www.w3.org/2005/07/scxml"
+       version="1.0"
+       initial="Main"
+       datamodel="ecmascript">
+  <state id="Main">
+    <!-- its initial state is Test1 -->
+    <initial>
+      <transition target="Test1"/>
+    </initial>
+
+    <!-- Really simple state showing the basic syntax. -->
+    <state id="Test1">
+      <initial>
+        <transition target="Test1Sub1"/>
+      </initial>
+      <!-- Runs before we go into the substate -->
+      <onentry> 
+        <log expr="'Inside Test1'"/>
+      </onentry>
+
+      <!-- Here is our first substate -->
+      <state id="Test1Sub1">
+        <onentry>
+          <log expr="'Inside Test1Sub1.'"/>
+        </onentry>
+        <onexit>
+          <log expr="'Leaving Test1Sub1'"/>
+        </onexit>
+        <!-- Go to Sub2 on Event1 -->
+        <transition event="Event1" target="Test1Sub2"/>
+      </state>
+
+      <!-- Here is the second substate 
+           It is final, so Test1 is done when we get here -->
+      <final id="Test1Sub2"/>
+
+      <!-- We get this event when we reach Test1Sub2. -->
+      <transition event="Test1.done" target="Test2"/>
+
+      <!-- We run this on the way out of Test1 -->
+      <onexit>
+        <log expr="'Leaving Test1...'"/>
+      </onexit>
+    </state>
+
+    <state id="Test2">
+      <initial>
+        <transition target="Test2Sub1"/>
+      </initial>
+
+        <state id="Test2Sub1">
+          <onentry>
+            <log expr="'Inside Test2Sub1'"/>
+          </onentry>
+          <transition event="Event2" target="Test2Sub2"/>
+        </state>
+  
+      <final id="Test2Sub2"/>
+
+      <!-- Test2Sub2 is defined as final, so this
+           event is generated when we reach it -->
+      <transition event="done.state.Test2" next="Test3"/>
+    </state>
+
+    <state id="Test3">
+      <initial>
+        <transition target="Test3Sub1"/>
+      </initial>
+
+      <state id="Test3Sub1">
+        <onentry>
+          <log expr="'Inside Test3Sub1...'"/>
+          <!-- Send our self an event in 5s -->
+          <send event="Timer"  delay="5s"/>
+        </onentry>
+        <!-- Transition on to Test4.
+             This will exit both us and our parent. -->
+        <transition event="Timer" target="Test4"/>
+        <onexit>
+          <log expr="'Leaving Test3Sub1...'"/>
+        </onexit>
+      </state>
+
+      <onexit>
+        <log expr="'Leaving Test3...'"/>
+      </onexit>
+    </state>
+    
+    <state id="Test4">
+      <onentry>
+        <log expr="'Inside Test4...'"/>
+      </onentry>
+      <initial>
+        <transition target="Test4Sub1"/>
+      </initial>
+
+      <state id="Test4Sub1">
+        <onexit>
+          <log expr="'Leaving Test4Sub1...'"/>
+        </onexit>
+        <!-- This transition causes the state to exit immediately
+             after entering Test4Sub1.  The transition has no event
+             or guard so it is always active -->
+        <transition target="Test5"/>
+      </state>
+    </state>
+       
+    <state id="Test5">
+      <onentry>
+        <log expr="'Inside Test5...'"/>
+      </onentry>
+      <initial>
+        <transition target="Test5P"/>
+      </initial>
+
+      <!-- Fire off parallel states.  In a more realistic example
+      the parallel substates Test5PSub1 and Test5PSub2 would themselves
+      have substates and would do some real work before transitioning to final substates -->
+      <parallel id="Test5P">
+        <state id="Test5PSub1" initial="Test5PSub1Final">
+           <final id="Test5PSub1Final"/>
+           </state>
+        <state id="Test5PSub2" initial="Test5PSub2Final">
+            <final id="Test5PSub2Final"/>
+            </state>
+        <onexit>
+          <log expr="'all parallel states done'"/>
+        </onexit>
+      </parallel>
+
+      <!-- The parallel states immediately transition to final substates,
+      so this event is generated immediately.   -->
+      <transition event="done.state.Test5P" target="Test6"/>
+    </state>
+
+    <!-- 
+         - This state shows invocation of an external component.
+         - We will use CCXML + VoiceXML actions as an example 
+         - as it is a good smoke test to show how it all 
+         - fits together. 
+         - Note: In a real app you would likely 
+         - split this over several states but we 
+         - are trying to keep it simple here. 
+    -->
+    <state id="Test6"
+           xmlns:ccxml="http://www.w3.org/2002/09/ccxml"
+           xmlns:v3="http://www.w3.org/2005/07/vxml3">
+      <datamodel>
+        <data id="ccxmlid" expr="32459"/>
+        <data id="v3id" expr="17620"/>
+        <data id="dest" expr="'tel:+18315552020'"/>
+        <data id="src" expr="'helloworld2.vxml'"/>
+        <data id="id" expr="'HelloWorld'"/>
+      </datamodel>
+
+      <onentry>
+        <!-- Use <send> a message to a CCXML Processor asking it to run createcall -->
+        <send target="ccxmlid" type="http://www.w3.org/TR/scxml/#BasicHTTPEventProcessor" event="ccxml:createcall" namelist="dest"/>
+      </onentry>
+
+      <transition event="ccxml:connection.connected">      
+        <!-- Here as a platform-specific extension we use example V3 
+             Custom Action Elements instead of send. The implementation of this logic 
+             would be platform-dependent. -->
+        <v3:form id="HelloWorld">
+          <v3:block><v3:prompt>Hello World!</v3:prompt></v3:block>          
+        </v3:form>
+      </transition>
+
+      <transition event="v3:HelloWorld.done">
+        <!-- Here we are using the low level <send> 
+             element to run a v3 form. Note that the event "v3:HelloWorld.done" 
+             is assumed either to be set/sent explicitly by the v3:form code or 
+             implicitly by some process outside of the v3:form -->
+        <send target="v3id" type="http://www.w3.org/TR/scxml/#BasicEventProcessor" event="v3:formstart" namelist="src id"/>
+      </transition>
+
+      <transition event="v3:HelloWorld2.done">
+        <!-- we use _event.data to access data in the event we're processing.
+             Again we assume the v3:HelloWorld2.done is set/sent from outside
+             this document -->
+        <ccxml:disconnect connectionid="_event.data.connectionid"/>      
+      </transition>
+
+      <transition event="ccxml:connection.disconnected" target="Done"/>
+  
+      <transition event="send.failed" target="Done">
+        <!-- If we get an error event we move to the Done state that 
+             is a final state. -->
+        <log expr="'Sending to and External component failed'"/>
+      </transition>
+
+      <onexit>
+        <log expr="'Finished with external component'"/>
+      </onexit>
+    </state>
+
+    <!-- This final state is an immediate child of Main
+         -  when we get here, Main.done is generated. -->
+    <final id="Done"/>
+    <!-- End of Main > -->
+  </state>
+</scxml>

--- a/impl/ex/priv/yaml/main.yaml
+++ b/impl/ex/priv/yaml/main.yaml
@@ -1,0 +1,75 @@
+statechart:
+  name: Main
+  root:
+    initial: Test1
+    states:
+    - name: Test1
+      initial: TestSub1
+      states:
+      - name: TestSub1
+        transitions:
+        - event: Event1
+          target: Test1Sub2
+      - name: Test1Sub2
+        type: final
+      transitions:
+        - event: Test1.done
+          target: Test2
+    - name: Test2
+      initial: Test2Sub1
+      states:
+      - name: Test2Sub1
+        transitions:
+        - event: Event2
+          target: Test2Sub2
+      - name: Test2Sub2
+        type: final
+      transitions:
+      - event: done.state.Test2
+        # Where did `next` come from?
+        next: Test3
+    - name: Test3
+      initial: Test3Sub1
+      states:
+      - name: Test3Sub1
+        transitions:
+        - event: Timer
+          target: Test4
+    - name: Test4
+      initial: Test4Sub1
+      states:
+      - name: Test4Sub1
+        transitions:
+        - target: Test5
+    - name: Test5
+      initial: Test5P
+    - name: Test5P
+      parallel:
+      - name: Test5PSub1
+        initial: Test5PSub1Final
+        state:
+        - name: Test5PSub1Final
+          final: true
+      - name: Test5PSub2
+        initial: Test5PSub2Final
+        states:
+        - name: Test5PSub2Final
+          final: true
+      transitions:
+      - event: done.state.Test5P
+        target: Test6
+    - name: Test6
+      transitions:
+        # TODO: this event had executable content
+        - event: ccxml:connection.connected
+        # TODO: this event had executable content
+        - event: v3:HelloWorld.done
+        # TODO: this event had executable content
+        - event: v::HellowWorld2.done
+        # TODO: this event had executable content
+        - event: ccxml:connection.disconnected
+          target: Done
+        - event: send.failed
+          target: Done
+    - name: Done
+      final: true


### PR DESCRIPTION
States are seeming to fall into 3 categories: parallel, final, or
regular state nodes. This change refactors the `Schema.State` node to
contain a type field where we can store what category the node falls
into.

Codec's were also updated to handle encountering `final` elements or
properties when building state nodes.

Lastly our current example machines did not contain any final states. I
went ahead and added the full `Main` example from the scxml spec
which has the whole gamut of capabilities that state machines can
handle.