### PR TITLE
Adds ZTree.find/2

### DIFF
--- a/impl/ex/lib/schema/ztree.ex
+++ b/impl/ex/lib/schema/ztree.ex
@@ -311,4 +311,14 @@ defmodule Statifier.Schema.ZTree do
   end
 
   def rparent({[], _}), do: {:error, :cannot_make_move}
+
+  @spec rparent!(t()) :: t()
+  @doc """
+  Same as rparent/1 but will throw if not able to make move
+  """
+  def rparent!(ztree) do
+    {:ok, ztree} = rparent(ztree)
+    ztree
+  end
+
 end

--- a/impl/ex/test/schema/ztree_test.exs
+++ b/impl/ex/test/schema/ztree_test.exs
@@ -95,5 +95,52 @@ defmodule Statifier.Schema.ZTreeTest do
       refute ZTree.parent?(ztree)
       assert ZTree.insert_child(ztree, 1) |> ZTree.children!() |> ZTree.parent?()
     end
+
+    test "can move up to parent without resetting siblings" do
+      ztree =
+        ZTree.root(0)
+        |> ZTree.insert_child(2)
+        |> ZTree.insert_child(1)
+
+      # move down and to second child
+      ztree =
+        ztree
+        |> ZTree.children!()
+        |> ZTree.right!()
+
+      assert ZTree.focus(ztree) == 2
+
+      # now back up to parent
+      ztree = ZTree.parent!(ztree)
+
+      # back to children
+      ztree = ZTree.children!(ztree)
+
+      assert ZTree.focus(ztree) == 2
+    end
+
+    test "can move up to parent and reset the siblings" do
+      ztree =
+        ZTree.root(0)
+        |> ZTree.insert_child(2)
+        |> ZTree.insert_child(1)
+
+      # move down and to second child
+      ztree =
+        ztree
+        |> ZTree.children!()
+        |> ZTree.right!()
+
+      assert ZTree.focus(ztree) == 2
+
+      # now back up to parent
+      ztree = ZTree.rparent!(ztree)
+
+      # back to children
+      ztree = ZTree.children!(ztree)
+
+      # since the siblings were reset we should see the first
+      assert ZTree.focus(ztree) == 1
+    end
   end
 end


### PR DESCRIPTION
The `find` API will receive a lot of use in the `Configuration` module
where we will need it to locate `State` nodes that are the targets of
`Transition`s.

The implementation of `find` could use some work to use the ZTree in a
more clever way to do the traversal, but since this is all internal
details this implementation will allow us to move forward.

* Add ZTree.rparent!/1
* Add ZTree.find/2