### PR TITLE
Runs elixir tests as part of CI workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,18 @@ jobs:
           danger_id: 'danger-pr'
         env:
           DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+
+  elixir-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-elixir@v1
+        with:
+          otp-version: '22.3'
+          elixir-version: '1.10.0'
+        env:
+          MIX_ENV: test
+      - run: |
+          mix deps.get
+          mix test
+        working-directory: ./impl/ex


### PR DESCRIPTION
At a later point we should consider how we are going to run tests for
multiple different implementations. Also it would be a nice to have to
only run tests for the changed implementations. For now this sets us up
to have the elixir suite running as part of our PR process.