### PR TITLE
Adds doctests to ZTree

### DIFF
--- a/impl/ex/test/schema/ztree_test.exs
+++ b/impl/ex/test/schema/ztree_test.exs
@@ -1,6 +1,7 @@
 defmodule Statifier.Schema.ZTreeTest do
   use ExUnit.Case, async: true
   alias Statifier.Schema.ZTree
+  doctest Statifier.Schema.ZTree
 
   describe "creating new elements" do
     test "can create a new tree given a root" do


### PR DESCRIPTION
ZTree can be a pretty abstract data structure to work with. Having
examples right in the docs really helps when triggering documentation on
hover. I have needed this several times to remember how things work.