### PR TITLE
Adds tree finding and iteration apis

### DIFF
--- a/impl/ex/lib/zipper/tree.ex
+++ b/impl/ex/lib/zipper/tree.ex
@@ -564,6 +564,39 @@ defmodule Statifier.Zipper.Tree do
     ztree
   end
 
+  @spec find_subtree(t(), (t(), focus :: any() -> boolean())) :: t() | nil
+  @doc """
+  Returns tree rooted at element based on `predicate` function - returning nil
+  when no element returns true for predicate.
+
+  The `predicate` function will be invoked with the tree at the position of the
+  current element and the current element. The tree argument can be used if
+  there is a need to look at surrounding elements of the current focus in order
+  for the `predicate` to make a decision.
+  """
+  def find_subtree(tree, pred) do
+    predicate_result = pred.(tree, focus(tree))
+    next_iteration = next(tree)
+
+    case {predicate_result, next_iteration} do
+      # element found
+      {true, _} ->
+        tree
+
+      # there is a next element to step to
+      {_false, {:ok, _value, new_tree}} ->
+        find_subtree(new_tree, pred)
+
+      # last element reached - do final check
+      {_false, {:complete, next_focus, next_tree}} ->
+        if pred.(next_tree, next_focus) do
+          next_tree
+        else
+          nil
+        end
+    end
+  end
+
   @spec next(t()) :: {:ok, any(), t()} | {:complete, any(), t()}
   @doc """
   Creates an iterator over a tree walking over all of the elements until

--- a/impl/ex/lib/zipper/tree.ex
+++ b/impl/ex/lib/zipper/tree.ex
@@ -554,4 +554,13 @@ defmodule Statifier.Zipper.Tree do
   end
 
   def rparent({[], _}), do: {:error, :cannot_make_move}
+
+  @spec rparent!(t()) :: t()
+  @doc """
+  Same as rparent/1 but will throw if not able to make move
+  """
+  def rparent!(ztree) do
+    {:ok, ztree} = rparent(ztree)
+    ztree
+  end
 end

--- a/impl/ex/test/zipper/tree_test.exs
+++ b/impl/ex/test/zipper/tree_test.exs
@@ -142,5 +142,30 @@ defmodule Statifier.Zipper.TreeTest do
 
       assert Tree.focus(tree) == 1
     end
+
+    test "can iterate over all the elements of a tree" do
+      # Tree
+      #              0
+      #          1       2
+      #               3
+      #             4
+      tree =
+        Tree.root(0)
+        |> Tree.insert_child(2)
+        |> Tree.insert_child(1)
+        |> Tree.children!()
+        |> Tree.right!()
+        |> Tree.insert_child(3)
+        |> Tree.children!()
+        |> Tree.insert_child(4)
+        |> Tree.rparent!()
+        |> Tree.rparent!()
+
+      assert {:ok, 1, tree} = Tree.next(tree)
+      assert {:ok, 2, tree} = Tree.next(tree)
+      assert {:ok, 3, tree} = Tree.next(tree)
+      assert {:ok, 4, tree} = Tree.next(tree)
+      assert {:complete, 0, _tree} = Tree.next(tree)
+    end
   end
 end

--- a/impl/ex/test/zipper/tree_test.exs
+++ b/impl/ex/test/zipper/tree_test.exs
@@ -96,5 +96,51 @@ defmodule Statifier.Zipper.TreeTest do
       refute Tree.parent?(ztree)
       assert Tree.insert_child(ztree, 1) |> Tree.children!() |> Tree.parent?()
     end
+
+    test "can move up to parent without resetting siblings" do
+      tree =
+        Tree.root(0)
+        |> Tree.insert_child(2)
+        |> Tree.insert_child(1)
+
+      # move down and to second child
+      tree =
+        tree
+        |> Tree.children!()
+        |> Tree.right!()
+
+      assert Tree.focus(tree) == 2
+
+      # now back up to parent
+      tree = Tree.parent!(tree)
+
+      # back to children
+      tree = Tree.children!(tree)
+
+      assert Tree.focus(tree) == 2
+    end
+
+    test "can move up to parent and reset the siblings" do
+      tree =
+        Tree.root(0)
+        |> Tree.insert_child(2)
+        |> Tree.insert_child(1)
+
+      # move down and to second child
+      tree =
+        tree
+        |> Tree.children!()
+        |> Tree.right!()
+
+      assert Tree.focus(tree) == 2
+
+      # now back up to parent
+      tree = Tree.rparent!(tree)
+
+      # back to children
+      tree = Tree.children!(tree)
+
+      assert Tree.focus(tree) == 1
+    end
   end
 end

--- a/impl/ex/test/zipper/tree_test.exs
+++ b/impl/ex/test/zipper/tree_test.exs
@@ -168,4 +168,35 @@ defmodule Statifier.Zipper.TreeTest do
       assert {:complete, 0, _tree} = Tree.next(tree)
     end
   end
+
+  describe "finding elements in tree" do
+    test "returns element when found" do
+      tree =
+        Tree.root(0)
+        |> Tree.insert_child(1)
+        |> Tree.children!()
+        |> Tree.insert_child(2)
+        |> Tree.parent!()
+
+      tree_at_element = Tree.find_subtree(tree, fn _tree, focus -> focus == 0 end)
+      assert Tree.focus(tree_at_element) == 0
+
+      tree_at_element = Tree.find_subtree(tree, fn _tree, focus -> focus == 1 end)
+      assert Tree.focus(tree_at_element) == 1
+
+      tree_at_element = Tree.find_subtree(tree, fn _tree, focus -> focus == 2 end)
+      assert Tree.focus(tree_at_element) == 2
+    end
+
+    test "returns nil when not found" do
+      tree =
+        Tree.root(0)
+        |> Tree.insert_child(1)
+        |> Tree.children!()
+        |> Tree.insert_child(2)
+        |> Tree.parent!()
+
+      assert nil == Tree.find_subtree(tree, fn _tree, focus -> focus == :not_in_tree end)
+    end
+  end
 end


### PR DESCRIPTION
Bolsters the `Tree` modules searching and iteration apis with `Tree.next/1` and `Tree.find/2`.

Next step is using these to initialize the initial state of a machine.
