### PR TITLE
Enhances send elements with proper content parsing

### DIFF
--- a/lib/statifier/parser/scxml/handler.ex
+++ b/lib/statifier/parser/scxml/handler.ex
@@ -72,9 +72,13 @@ defmodule Statifier.Parser.SCXML.Handler do
     do: {:ok, StateStack.pop_element(state)}
 
   @impl Saxy.Handler
-  def handle_event(:characters, _character_data, state) do
-    # Ignore text content for now since SCXML elements don't have mixed content
-    {:ok, state}
+  def handle_event(:characters, character_data, state) do
+    # Handle text content for elements that need it (like <content>)
+    case StateStack.handle_characters(character_data, state) do
+      {:ok, updated_state} -> {:ok, updated_state}
+      # Ignore text for other elements
+      :not_handled -> {:ok, state}
+    end
   end
 
   # Private helper functions for element handling

--- a/lib/statifier/parser/scxml/state_stack.ex
+++ b/lib/statifier/parser/scxml/state_stack.ex
@@ -724,4 +724,33 @@ defmodule Statifier.Parser.SCXML.StateStack do
     alias Statifier.Actions.IfAction
     IfAction.new(conditional_blocks, if_container[:location])
   end
+
+  @doc """
+  Handle text content for elements that support it (like <content>).
+  """
+  @spec handle_characters(String.t(), map()) :: {:ok, map()} | :not_handled
+  def handle_characters(character_data, %{stack: [{element_name, element} | _rest]} = state) do
+    case element_name do
+      "content" ->
+        # Add text content to content element
+        trimmed_content = String.trim(character_data)
+
+        if trimmed_content != "" do
+          updated_content = %{element | content: trimmed_content}
+          updated_stack = replace_top_element(state.stack, {"content", updated_content})
+          {:ok, %{state | stack: updated_stack}}
+        else
+          # Ignore whitespace-only content
+          {:ok, state}
+        end
+
+      _other_element ->
+        :not_handled
+    end
+  end
+
+  def handle_characters(_character_data, _state), do: :not_handled
+
+  # Helper to replace the top element on the stack
+  defp replace_top_element([_head | tail], new_head), do: [new_head | tail]
 end

--- a/test/passing_tests.json
+++ b/test/passing_tests.json
@@ -69,6 +69,7 @@
     "test/scion_tests/parallel_interrupt/test6_test.exs",
     "test/scion_tests/parallel_interrupt/test8_test.exs",
     "test/scion_tests/parallel_interrupt/test9_test.exs",
+    "test/scion_tests/send_internal/test0_test.exs",
     "test/scion_tests/targetless_transition/test0_test.exs"
   ],
   "w3c_tests": [

--- a/test/statifier/parser/scxml/content_parsing_integration_test.exs
+++ b/test/statifier/parser/scxml/content_parsing_integration_test.exs
@@ -1,0 +1,173 @@
+defmodule Statifier.Parser.SCXML.ContentParsingIntegrationTest do
+  use ExUnit.Case, async: true
+
+  alias Statifier.Parser.SCXML
+
+  describe "content element text parsing integration" do
+    test "parses send with content element containing text" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <content>Hello World</content>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      # Find the send action in the onentry
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Verify content was parsed correctly
+      assert send_action.content != nil
+      assert send_action.content.content == "Hello World"
+      assert send_action.content.expr == nil
+    end
+
+    test "parses send with content element containing whitespace-trimmed text" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <content>
+                Multi-line content
+                with whitespace
+              </content>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Content should be trimmed but preserve internal structure
+      expected_content = "Multi-line content\n          with whitespace"
+      assert send_action.content.content == expected_content
+    end
+
+    test "parses send with content element having expr attribute (no text content)" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <content expr="'Dynamic content'"/>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Should have expr but no text content
+      assert send_action.content.expr == "'Dynamic content'"
+      assert send_action.content.content == nil
+    end
+
+    test "parses send with empty content element" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <content></content>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Empty content should remain nil
+      assert send_action.content.content == nil
+      assert send_action.content.expr == nil
+    end
+
+    test "parses send with content containing only whitespace" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <content>
+
+              </content>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Whitespace-only content should be ignored
+      assert send_action.content.content == nil
+    end
+
+    test "parses send with mixed content and params (content takes precedence)" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          <onentry>
+            <send event="test" target="#_internal">
+              <param name="key" expr="'value'"/>
+              <content>Content takes precedence</content>
+            </send>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      [send_action] = state.onentry_actions
+
+      # Should have both content and params
+      assert send_action.content.content == "Content takes precedence"
+      assert length(send_action.params) == 1
+      assert hd(send_action.params).name == "key"
+    end
+
+    test "ignores text content in non-content elements" do
+      xml = """
+      <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
+        <state id="a">
+          Some text that should be ignored
+          <onentry>
+            <log expr="'test'"/>
+          </onentry>
+        </state>
+      </scxml>
+      """
+
+      # Should parse successfully without errors
+      {:ok, document} = SCXML.parse(xml)
+
+      [state] = document.states
+      assert state.id == "a"
+      assert length(state.onentry_actions) == 1
+    end
+  end
+end


### PR DESCRIPTION
Fixes content element parsing to capture text content within <content> elements. Previously the SAX parser ignored all text content, causing send actions with content elements to have empty event data instead of the specified text.

Adds StateStack.handle_characters to process text content for content elements while preserving existing behavior of ignoring text in other SCXML elements.

Enables send_internal/test0_test.exs which uses both namelist/param and content send patterns. Send implementation already supported namelist and param elements correctly - only content text parsing was missing.

Updates regression baseline to include newly passing test.

🤖 Generated with [Claude Code](https://claude.ai/code)