### PR TITLE
Fixes nested if parsing in SAX parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Statifier - SCXML State Machines for Elixir
 
-[![CI](https://github.com/riddler/statifier/workflows/CI/badge.svg?branch=main)](https://github.com/riddler/statifier/actions)
-[![Coverage](https://codecov.io/gh/riddler/statifier/branch/main/graph/badge.svg)](https://codecov.io/gh/riddler/statifier)
+[![CI](https://github.com/riddler/statifier/actions/workflows/ci.yml/badge.svg)](https://github.com/riddler/statifier/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/riddler/statifier/branch/main/graph/badge.svg)](https://codecov.io/gh/riddler/statifier)
+[![Hex.pm Version](https://img.shields.io/hexpm/v/statifier.svg)](https://hex.pm/packages/statifier)
+[![Hex Docs](https://img.shields.io/badge/hex-docs-lightgreen.svg)](https://hexdocs.pm/statifier/)
+
+> ⚠️ **Active Development Notice**  
+> This project is still under active development and things may change even though it is passed version 1. APIs, features, and behaviors may evolve as we continue improving SCXML compliance and functionality.
 
 An Elixir implementation of SCXML (State Chart XML) state charts with a focus on W3C compliance.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -7,17 +7,7 @@ if config_env() == :dev do
 
   config :logger, :console,
     format: "[$level] $message $metadata\n",
-    metadata: [
-      :current_state,
-      :event,
-      :action_type,
-      :state_id,
-      :phase,
-      :transition_type,
-      :source_state,
-      :condition,
-      :targets
-    ]
+    metadata: :all
 
   # Default Statifier logging configuration for dev
   config :statifier,

--- a/lib/statifier/parser/scxml/state_stack.ex
+++ b/lib/statifier/parser/scxml/state_stack.ex
@@ -584,6 +584,17 @@ defmodule Statifier.Parser.SCXML.StateStack do
     {:ok, %{state | stack: [{"transition", updated_transition} | rest]}}
   end
 
+  # Handle nested if action within parent if container
+  def handle_if_end(
+        %{stack: [{_element_name, nested_if_container} | [{"if", parent_if_container} | rest]]} =
+          state
+      ) do
+    # Create IfAction from nested if container and add to parent if container
+    nested_if_action = create_if_action_from_container(nested_if_container)
+    updated_parent_container = add_action_to_current_block(parent_if_container, nested_if_action)
+    {:ok, %{state | stack: [{"if", updated_parent_container} | rest]}}
+  end
+
   def handle_if_end(state) do
     # If element not in an onentry/onexit context, just pop it
     {:ok, pop_element(state)}

--- a/lib/statifier/parser/scxml/state_stack.ex
+++ b/lib/statifier/parser/scxml/state_stack.ex
@@ -6,6 +6,8 @@ defmodule Statifier.Parser.SCXML.StateStack do
   and updating parent elements when child elements are completed.
   """
 
+  alias Statifier.Actions.IfAction
+
   @doc """
   Handle the end of a state element by adding it to its parent.
   """
@@ -853,7 +855,6 @@ defmodule Statifier.Parser.SCXML.StateStack do
       end)
 
     # Create IfAction with collected blocks
-    alias Statifier.Actions.IfAction
     IfAction.new(conditional_blocks, if_container[:location])
   end
 

--- a/test/passing_tests.json
+++ b/test/passing_tests.json
@@ -5,7 +5,7 @@
     "test/statifier/**/*_test.exs",
     "test/mix/**/*_test.exs"
   ],
-  "last_updated": "2025-08-31",
+  "last_updated": "2025-09-02",
   "scion_tests": [
     "test/scion_tests/actionSend/send1_test.exs",
     "test/scion_tests/actionSend/send2_test.exs",
@@ -46,6 +46,7 @@
     "test/scion_tests/history/history4b_test.exs",
     "test/scion_tests/history/history5_test.exs",
     "test/scion_tests/history/history6_test.exs",
+    "test/scion_tests/if_else/test0_test.exs",
     "test/scion_tests/misc/deep_initial_test.exs",
     "test/scion_tests/more_parallel/test0_test.exs",
     "test/scion_tests/more_parallel/test10_test.exs",


### PR DESCRIPTION
Adds support for nested if blocks by handling the case where an if element ends while nested inside another if container. Previously, nested if blocks were lost during parsing instead of being created as separate IfAction instances.

Changes:
- Adds new pattern match case in handle_if_end for nested if containers
- Creates IfAction from nested if container and adds to parent block
- Enables proper parsing of complex conditional logic with nested if/else

Fixes SCION test if_else/test0 which now passes.

🤖 Generated with [Claude Code](https://claude.ai/code)